### PR TITLE
fix generate_gateload_configs.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ ansible-playbook -l $KEYNAME configure-sync-gateway-writer.yml
 
 ```
 * `cd ../.. && python generate_gateload_configs.py` 
-* `ansible-playbook -l $KEYNAME start-gateload.yml`
+* `cd ./ansible/playbooks && ansible-playbook -l $KEYNAME start-gateload.yml`
 ```
 
 ### Starting Gatling tests
@@ -152,7 +152,7 @@ If you need to deploy multiple perf runner clusters into the same AWS account, b
 For example if you have provisioned each cluster using a different IAM use account, you could partition the hosts by the IAM user key pair name e.g. If a users key pair name is 'my_keypair' then the following command will partition the host groups to only those provisioned by that user.
 
 ```
-$ ansible-playbook -l key_tleyden hello-world.yml
+$ ansible-playbook -l key_my_keypair hello-world.yml
 ```
 
 ## Splunk setup

--- a/generate_gateload_configs.py
+++ b/generate_gateload_configs.py
@@ -116,17 +116,16 @@ def main():
         
         # calculate the user offset 
         user_offset = idx * 13000 
+        # assign a sync gateway to this gateload, get its ip
+        # upload only on remote hosts with sync_gateway_ips
+        if gateload_dict["ec2_private_ip_address"] in sync_gateway_ips:
+            gateload_ec2_id = gateload_dict["ec2_id"]
 
-        # assign a sync gateway to this gateload, get its ip 
-        sync_gateway_private_ip = sync_gateway_ips[idx]
-
-        gateload_ec2_id = gateload_dict["ec2_id"]
-
-        upload_gateload_config(
-            gateload_ec2_id,
-            sync_gateway_private_ip,
-            user_offset
-        )
+            upload_gateload_config(
+                gateload_ec2_id,
+                gateload_dict["ec2_private_ip_address"],
+                user_offset
+            )
 
     print "Finished successfully"
 


### PR DESCRIPTION
we iterate through gateload_dicts with tag_Type_gateload but we need to upload config only on hosts from sync_gateway_ips
