### PR TITLE
Allow passing in local custom sync_gateway_config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ This script performs a series of steps for you
 
 ### Provision the cluster
 
-Install Couchbase Server and build sync_gateway from source with optional --branch (master is default)
+Install Couchbase Server and build sync_gateway from source with optional --branch (master is default).
+Additionally, you can provide an optional custom sync_gateway_config.json file. If this is not specified, it will use the config in "files/sync_gateway_config.json"
 
 ```
 python provision_cluster.py 
     --server-version=3.1.0
     --build-from-source
     --branch="feature/distributed_cache_stale_ok"
+    --sync-gateway-config-file="<path to your sync_gateway_config.json file>"
 ```
 
 (IN PROGRESS) Install Couchbase Server and download sync_gateway binary (1.1.1 is default)

--- a/ansible/playbooks/install-sync-gateway-service.yml
+++ b/ansible/playbooks/install-sync-gateway-service.yml
@@ -15,6 +15,7 @@
   sudo: true
   vars:
     writer: "false"
+    sync_gateway_config_filepath: "files/sync_gateway_config.json"
   tasks:
   - name: set couchbase_server_primary_node variable
     set_fact:
@@ -30,7 +31,7 @@
   - name: change permissions of sync gateway executable
     file: path=/home/sync_gateway/sync_gateway mode=a+x
   - name: copy sync gateway config to host
-    template: src=files/sync_gateway_config.json dest=/home/sync_gateway/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
+    template: src={{ sync_gateway_config_filepath }} dest=/home/sync_gateway/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true
   - name: install sync gateway service
     shell: ./sync_gateway_service_install.sh --sgpath=/home/sync_gateway/sync_gateway chdir=/home/centos/sync_gateway/service
   - name: update service file to enable garbage collector debugging

--- a/scripts/provision_cluster.py
+++ b/scripts/provision_cluster.py
@@ -17,6 +17,10 @@ parser.add_option("-g", "--sync-gateway-version",
                   action="store", type="string", dest="sync_gateway_version", default="1.1.1",
                   help="sync_gateway binary version to download")
 
+parser.add_option("-f", "--sync-gateway-config-file",
+                  action="store", type="string", dest="sync_gateway_config_file", default="files/sync_gateway_config.json",
+                  help="path to your sync_gateway_config file")
+
 parser.add_option("-c", "--build-from-source",
                   action="store_true", dest="build_from_source", default=False,
                   help="build sync_gateway from source")
@@ -31,12 +35,9 @@ arg_parameters = sys.argv[1:]
 
 COUCHBASE_SERVER_VERSION = opts.server_version
 SYNC_GATEWAY_VERSION = opts.sync_gateway_version
+SYNC_GATEWAY_CONFIG_FILE_PATH = opts.sync_gateway_config_file
 BUILD_FROM_SOURCE = opts.build_from_source
 BRANCH = opts.source_branch
-
-current_time = time.time()
-step_times = {}
-
 
 def run_ansible_playbook(script_name, extra_vars=""):
     if extra_vars != "":
@@ -56,7 +57,7 @@ else:
     print "Build stable"
     run_ansible_playbook("install-sync-gateway-release.yml", "couchbase_sync_gateway_centos_ee_version={}".format(SYNC_GATEWAY_VERSION))
 
-run_ansible_playbook("install-sync-gateway-service.yml")
+run_ansible_playbook("install-sync-gateway-service.yml", "sync_gateway_config_filepath={}".format(SYNC_GATEWAY_CONFIG_FILE_PATH))
 run_ansible_playbook("install-splunkforwarder.yml")
 
 


### PR DESCRIPTION
Fixes #13 

@tleyden  Right now this is only for a local custom config file. Is that sufficient for our purposes or should it be able to grab from remote as well?

README is update with the extra option in provision_cluster.py
