### PR TITLE
Wild card splunk monitoring path for gatling simulation logs

### DIFF
--- a/ansible/playbooks/install-splunkforwarder.yml
+++ b/ansible/playbooks/install-splunkforwarder.yml
@@ -191,7 +191,7 @@
   - file: path=/home/projects/sg-gatling-load/themes/gateload-sim/target/gatling/results state=directory
     sudo: true
   - name: Capture gateload logs
-    shell: /opt/splunkforwarder/bin/splunk add monitor /home/projects/sg-gatling-load/themes/gateload-sim/target/gatling/results -index main -sourcetype gatling_results -auth admin:changeme
+    shell: /opt/splunkforwarder/bin/splunk add monitor /home/projects/sg-gatling-load/themes/.../target/gatling/results/.../simulation.log -index main -sourcetype gatling_results -auth admin:changeme
     sudo: true
 
 


### PR DESCRIPTION
Wild card splunk monitoring path for gatling simulation logs so that logs will be uploaded for any theme.

Fixes #22
