### PR TITLE
Create var 'couchbase_server_primary_node' which is required when copying sync_gateway.config

### DIFF
--- a/ansible/playbooks/configure-sync-gateway-writer.yml
+++ b/ansible/playbooks/configure-sync-gateway-writer.yml
@@ -4,6 +4,7 @@
   sudo: true
   vars:
     writer: "true"
+    couchbase_server_primary_node: "{{hostvars[ec2_public_dns_name]['ec2_private_dns_name']}}"
   tasks:
   - name: copy sync gateway config to host
     template: src=files/sync_gateway_config.json dest=/home/sync_gateway/sync_gateway.json owner=sync_gateway group=sync_gateway mode=0644 force=true


### PR DESCRIPTION
Fixes #25 
