### PR TITLE
Stop sync gw first

### DIFF
--- a/ansible/playbooks/reset-sync-gateway.yml
+++ b/ansible/playbooks/reset-sync-gateway.yml
@@ -1,4 +1,14 @@
 ---
+- hosts: tag_Type_syncgateway
+  remote_user: centos
+  sudo: true
+  tasks:
+  - name: stop sync_gateway service
+    service: name=sync_gateway state=stopped
+  - name: delete sync_gateway logs
+    shell: rm -f /home/sync_gateway/logs/*.log
+  - name: delete sync_gateway pindex files
+    shell: rm -rf /home/sync_gateway/*.pindex
 - hosts: tag_Type_couchbaseserver
   any_errors_fatal: true
   remote_user: centos
@@ -29,11 +39,5 @@
   remote_user: centos
   sudo: true
   tasks:
-  - name: stop sync_gateway service
-    service: name=sync_gateway state=stopped
-  - name: delete sync_gateway logs
-    shell: rm -f /home/sync_gateway/logs/*.log
-  - name: delete sync_gateway pindex files
-    shell: rm -rf /home/sync_gateway/*.pindex
   - name: start sync_gateway service
     service: name=sync_gateway state=started


### PR DESCRIPTION
Stop the sync gateway, then flush couchbase, then start the sync gateway.

Solves the issue that I saw previously where after the couchbase bucket was flushed, the still running sync gateway would be adding docs to it.
